### PR TITLE
Fixed Windows RT support.

### DIFF
--- a/contrib/SynapticsTouch.vcxproj
+++ b/contrib/SynapticsTouch.vcxproj
@@ -81,6 +81,8 @@
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>KMDF</DriverType>
+    <KMDF_VERSION_MAJOR>1</KMDF_VERSION_MAJOR>
+    <KMDF_VERSION_MINOR>11</KMDF_VERSION_MINOR>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">

--- a/src/device.c
+++ b/src/device.c
@@ -459,7 +459,7 @@ OnPrepareHardware(
 
 	if (devContext->HasResetGpio)
 	{
-		status = OpenIOTarget(devContext, devContext->ResetGpioId, GENERIC_READ | GENERIC_WRITE, &devContext->ResetGpio);
+		status = OpenIOTarget(devContext, devContext->ResetGpioId, GENERIC_WRITE, &devContext->ResetGpio);
 		if (!NT_SUCCESS(status)) {
 			Trace(TRACE_LEVEL_ERROR, TRACE_DRIVER, "OpenIOTarget failed for Reset GPIO 0x%x", status);
 			goto exit;

--- a/src/init.c
+++ b/src/init.c
@@ -859,7 +859,7 @@ Return Value:
 
 	controller = (RMI4_CONTROLLER_CONTEXT*)ControllerContext;
 
-	if (NULL != controller->BklContext)
+	if (controller != NULL && controller->BklContext != NULL)
 	{
 		TchBklDeinitialize(controller->BklContext);
 		controller->BklContext = NULL;


### PR DESCRIPTION
I found out that Windows RT is being picky and it don't allow `GENERIC_READ` on the GPIO pin. The original driver from WP only set `GENERIC_WRITE` and by doing that, fixed our driver for Windows RT.

I also fixed a NULL dereference in case it fails to open the GPIO pin.